### PR TITLE
fix trivial two problems

### DIFF
--- a/docs/pages/2019_ISSP_Chiba_Japan/sections/setup.rst
+++ b/docs/pages/2019_ISSP_Chiba_Japan/sections/setup.rst
@@ -26,7 +26,7 @@ configuration, to do so:
 -  Generate private and pubilc ssh key pair by ``ssh-keygen -f
    aiida_tutorial``.
 -  Copy the public key to VM by ``ssh-copy-id -i
-   ~/.ssh/aiida-tutorial.pub max@127.0.0.1 -p 2222`` and type the
+   ~/.ssh/aiida_tutorial.pub max@127.0.0.1 -p 2222`` and type the
    default password ``moritz``.
 
 
@@ -63,7 +63,7 @@ Afterwards you can connect to VM using this simple command:
    .. code:: console
 
       ssh \
-            -i ~/.ssh/aiida-tutorial \
+            -i ~/.ssh/aiida_tutorial \
             -L 8888:localhost:8888 \
             -L 5000:localhost:5000 \
             -o ServerAliveInterval=120 \

--- a/docs/pages/2019_ISSP_Chiba_Japan/sections/verdi_shell.rst
+++ b/docs/pages/2019_ISSP_Chiba_Japan/sections/verdi_shell.rst
@@ -240,7 +240,6 @@ You can do it using commands like
     structure.append_atom(position=(alat/4., alat/4., alat/4.), symbols="Si")
 
 for the first ‘Si’ atom.
-Repeat it for the other atomic site (0, 0, 0).
 You can access and inspect the structure sites with the command
 
 .. code:: python

--- a/docs/pages/2019_ISSP_Chiba_Japan/sections/verdi_shell.rst
+++ b/docs/pages/2019_ISSP_Chiba_Japan/sections/verdi_shell.rst
@@ -236,6 +236,7 @@ You can do it using commands like
 
 .. code:: python
 
+    structure.append_atom(position=(0., 0., 0.), symbols="Si")
     structure.append_atom(position=(alat/4., alat/4., alat/4.), symbols="Si")
 
 for the first ‘Si’ atom.


### PR DESCRIPTION
I fixed trivial two things,

1.  In setup.rst, I found some ssh key names were 'aiida-tutorial' not 'aiida_tutorial'. So I fixed some 'aiida-tutorial' to 'aiida_tutorial'.

2. In verdi_shell.rst, the atom position (0,0,0) was missing in Si diamond structure, so I add it.

Thanks,
Keiyu Mizokami